### PR TITLE
Fix Cannot GET /

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,11 @@ app.use(bodyParser.json());
 
 app.use('/api/subscription', subscriptionRoute);
 
+// simple root route so opening the server URL works
+app.get('/', (req, res) => {
+  res.send('BabyCare Pro backend');
+});
+
 app.listen(3001, () => {
   console.log('Backend running on port 3001');
 });


### PR DESCRIPTION
## Summary
- add a simple root route to the Express backend

## Testing
- `npm install` (backend)
- `node src/index.js` and `curl http://localhost:3001/`

------
https://chatgpt.com/codex/tasks/task_e_68483bd6b2748326aa190e23de1c9839